### PR TITLE
Retry try_contribute call if we get back an error

### DIFF
--- a/cmd/participant/auth.go
+++ b/cmd/participant/auth.go
@@ -91,7 +91,7 @@ func startSIWEServer(client *Client) error {
 
 func startSIWEPage(url string) error {
 	fmt.Printf("Signing in with ethereum on %v\n", url)
-	cmd := exec.Command("chromium", url)
+	cmd := exec.Command("xdg-open", url)
 	if err := cmd.Start(); err != nil {
 		return err
 	}

--- a/cmd/participant/landing.go
+++ b/cmd/participant/landing.go
@@ -107,17 +107,13 @@ func (c *Client) TryContribute() error {
 		return err
 	}
 
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		// Success!
-		return nil
-	}
-
 	var errorUnm ErrorStruct
-	if err := json.Unmarshal(responseData, &errorUnm); err != nil {
-		return fmt.Errorf("error unmarshaling error data \"%v\": %w", string(responseData), err)
+	if err := json.Unmarshal(responseData, &errorUnm); err == nil && len(errorUnm.Error) > 0 {
+		return fmt.Errorf("%v: %v", errorUnm.Code, errorUnm.Error)
 	}
 
-	return fmt.Errorf("%v: %v", errorUnm.Code, errorUnm.Error)
+	fmt.Println(string(responseData))
+	return handleStatus(resp.StatusCode)
 }
 
 func (c *Client) RequestLink() error {

--- a/cmd/participant/landing.go
+++ b/cmd/participant/landing.go
@@ -107,13 +107,17 @@ func (c *Client) TryContribute() error {
 		return err
 	}
 
-	var errorUnm ErrorStruct
-	if err := json.Unmarshal(responseData, &errorUnm); err == nil {
-		return fmt.Errorf("%v: %v", errorUnm.Code, errorUnm.Error)
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		// Success!
+		return nil
 	}
 
-	fmt.Println(string(responseData))
-	return handleStatus(resp.StatusCode)
+	var errorUnm ErrorStruct
+	if err := json.Unmarshal(responseData, &errorUnm); err != nil {
+		return fmt.Errorf("error unmarshaling error data \"%v\": %w", string(responseData), err)
+	}
+
+	return fmt.Errorf("%v: %v", errorUnm.Code, errorUnm.Error)
 }
 
 func (c *Client) RequestLink() error {

--- a/cmd/participant/landing.go
+++ b/cmd/participant/landing.go
@@ -109,8 +109,7 @@ func (c *Client) TryContribute() error {
 
 	var errorUnm ErrorStruct
 	if err := json.Unmarshal(responseData, &errorUnm); err == nil {
-		fmt.Printf("Error: %v", errorUnm)
-		return errors.New(errorUnm.Error)
+		return fmt.Errorf("%v: %v", errorUnm.Code, errorUnm.Error)
 	}
 
 	fmt.Println(string(responseData))


### PR DESCRIPTION
The auth portion worked for me :) I haven't made it past `try_contribute` yet because of the sequencer but this retries `try_contribute` if we get back an error (which is almost always "another contribution is in progress").

I also switched the browser from `chromium` to `xdg-open` to respect users preferences on Linux. This theoretically breaks other OSs, but I'm not sure they'd be using chromium as opposed to chrome in the first place. If requested I can add different commands for different OSs, or just revert that portion of my change.