### PR TITLE
Fix ceremony saving and improve sign in experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 cmd/participant/participant
 cmd/coordinator/coordinator
 cmd/coordinator/history
+contribution.json

--- a/cmd/participant/auth.go
+++ b/cmd/participant/auth.go
@@ -16,6 +16,7 @@ func (c *Client) Login() error {
 		return err
 	}
 
+	fmt.Printf("Alternative GitHub sign in URL: %v\n", links.GithubAuthURL)
 	if err := startSIWEPage(links.EthAuthURL); err != nil {
 		return err
 	}
@@ -58,7 +59,8 @@ func startSIWEPage(url string) error {
 	fmt.Printf("Signing in with ethereum on %v\n", url)
 	cmd := exec.Command("xdg-open", url)
 	if err := cmd.Start(); err != nil {
-		return err
+		fmt.Printf("Failed to launch browser. Please open the above URL manually. Error: %v\n", err)
+		return nil
 	}
 	return cmd.Wait()
 }

--- a/cmd/participant/main.go
+++ b/cmd/participant/main.go
@@ -78,11 +78,11 @@ func runParticipation(client *Client) error {
 		return err
 	}
 
-	marshalled, err := json.Marshal(contribution)
+	marshalled, err := json.Marshal(newCeremony)
 	if err != nil {
 		return err
 	}
-	ioutil.WriteFile("contribution", marshalled, fs.ModeAppend)
+	ioutil.WriteFile("contribution.json", marshalled, fs.ModeAppend | 0o644)
 
 	fmt.Println("Successfully contributed, exiting")
 	return nil


### PR DESCRIPTION
We were previously marshalling the state of the ceremony before we contributed, but I think it was meant to save the contribution itself, which is useful for verifying that it was included in the final ceremony result.

This PR also prints out the github sign in URL and doesn't quit if we fail to start the browser.